### PR TITLE
Fix pagination not being followed when listing paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Listing elements inside a path is no longer limited to 1000 elements, it now follows the pagination
+
 ## 4.1.0 - 2024-03-23
 
 ### Added


### PR DESCRIPTION
## Problem

For the past 2 weeks the [Periodic CI](https://github.com/Innmind/S3/actions/workflows/periodic.yml) fails when trying to list all files at the root of the bucket. It only returns 1000 files when the bucket contains around 1200.

## Solution

When listing the paths follow the pagination by doing another call with the `NextContinuationToken`.