### PR TITLE
Fix error when listing files inside an empty folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Listing files inside an empty folder was throwing an error
+
 ## 4.1.2 - 2024-06-17
 
 ### Fixed


### PR DESCRIPTION
## Problem

When investigating the last error of the [Periodic CI](https://github.com/Innmind/S3/actions/workflows/periodic.yml) I created an empty folder via the web interface of Scaleway.

When then running the CI it throwed an exception saying a `Path` was empty.

Turns out that when asking the list of files for an empty folder it returns the folder path. The current code removes the path to only keep the file name, thus creating an empty string.

## Solution

Exclude this kind of path from the folder list of files.