### PR TITLE
Delete files with the same name as the directory being uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Uploading a file and then a directory with the same name didn't remove the file.
+
 ## 4.1.3 - 2024-10-26
 
 ### Fixed

--- a/src/Filesystem/Adapter.php
+++ b/src/Filesystem/Adapter.php
@@ -130,6 +130,15 @@ final class Adapter implements AdapterInterface
         }
 
         if ($file instanceof Directory) {
+            // Delete any file that may exist with the same name as the directory
+            $_ = $this
+                ->bucket
+                ->get($path)
+                ->flatMap(fn() => $this->bucket->delete($path))
+                ->match(
+                    static fn() => null,
+                    static fn() => null,
+                );
             $all = match ($this->keepEmptyDirectories) {
                 true => $file->all()->add(File::named(self::VOID_FILE, Content::none())),
                 false => $file->all(),


### PR DESCRIPTION
## Problem

When a file is uploaded then a directory is uploaded with the same name doesn't remove the file. The resulting problem is that when fetching the name you'll get the file instead of the directory.

## Solution

When uploading a directory remove any file with the same name.

## Note

In order to know if there's a file with the same name we need to fetch it, this may cause performance issues depending on the user file structure and files size.