### PR TITLE
Fix files list being deferred instead of lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Uploading a file and then a directory with the same name didn't remove the file.
+- The list of files inside a directory was kept in memory.
 
 ## 4.1.3 - 2024-10-26
 

--- a/src/Bucket/OverHttp.php
+++ b/src/Bucket/OverHttp.php
@@ -166,7 +166,7 @@ final class OverHttp implements Bucket
             $next = [];
         }
 
-        return Sequence::lazy(function() {
+        return Sequence::lazy(function() use ($path, $query, $next) {
             yield ($this->fulfill)($this->request(
                 Method::get,
                 $this->bucket->path(),
@@ -211,7 +211,7 @@ final class OverHttp implements Bucket
                                 ->keep(Instance::of(Element::class))
                                 ->map(static fn($token) => $token->content())
                                 ->match(
-                                    fn($token) => fn() => yield $this->paginate(
+                                    fn($token) => $this->paginate(
                                         $path,
                                         $query,
                                         $token,


### PR DESCRIPTION
## Problem

The first page loaded when listing the files inside a directory is a deferred one. This means that even though the next pages are declared as lazy the whole `Sequence` is deferred.

## Solution

Wrap the first call in a lazy `Sequence` to make the whole list lazy.